### PR TITLE
Add reasons for failure to JSON Schema validation

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -17,6 +17,11 @@ class Record < ApplicationRecord
   end
 
   def store_metadata_validation
-    self.json_valid = JsonValidator.valid?(metadata)
+    self.json_valid = validator.valid?
+    self.validation_report = validator.report
+  end
+
+  def validator
+    @validator ||= JsonValidator.new(metadata)
   end
 end

--- a/app/services/json_validator.rb
+++ b/app/services/json_validator.rb
@@ -11,7 +11,11 @@ class JsonValidator
     @json = json
   end
 
+  def report
+    @report ||= JSON::Validator.fully_validate(JSON_SCHEMA_PATH, json)
+  end
+
   def valid?
-    JSON::Validator.validate JSON_SCHEMA_PATH, json
+    report.empty?
   end
 end

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -3,6 +3,7 @@
   <h1 class="govuk-heading-l"><%= @record.name %></h1>
 
   <p><%= valid_record_tag(@record) %></p>
+  <%= govuk_list(@record.validation_report) unless @record.json_valid? %>
 
   <h2 class="govuk-heading-m govuk-!-padding-top-2">Metadata</h1>
   <pre>

--- a/db/migrate/20241209110557_add_validation_report_to_records.rb
+++ b/db/migrate/20241209110557_add_validation_report_to_records.rb
@@ -1,0 +1,5 @@
+class AddValidationReportToRecords < ActiveRecord::Migration[8.0]
+  def change
+    add_column :records, :validation_report, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_05_113814) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_09_110557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_113814) do
     t.datetime "updated_at", null: false
     t.boolean "json_valid"
     t.string "remote_id"
+    t.text "validation_report", array: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -8,12 +8,22 @@ RSpec.describe Record, type: :model do
       expect(record.json_valid).to be_falsey
     end
 
+    it "add the validation results to validation_report" do
+      expect(record.validation_report).to be_present
+      expect(record.validation_report).to be_a(Array)
+      expect(record.validation_report.first).to be_a(String)
+    end
+
     context "with valid data" do
       let(:metadata) { json_from_fixture("dataset.json") }
       let(:record) { create :record, metadata: }
 
       it "sets json_valid as true" do
         expect(record.json_valid).to be_truthy
+      end
+
+      it "sets validation_report as empty" do
+        expect(record.validation_report).to be_empty
       end
     end
   end

--- a/spec/services/json_validator_spec.rb
+++ b/spec/services/json_validator_spec.rb
@@ -1,18 +1,40 @@
 require "rails_helper"
 
 RSpec.describe JsonValidator, type: :service do
-  describe ".valid?" do
-    let(:json) { json_from_fixture("dataset.json") }
+  let(:json) { json_from_fixture("dataset.json") }
+  let(:invalid) do
+    { invalid: :content }.to_json
+  end
 
+  describe ".valid?" do
     it "is true for valid json" do
       expect(described_class.valid?(json)).to be_truthy
     end
 
     context "with invalid json" do
-      let(:json) { { invalid: :content }.to_json }
+      let(:json) { invalid }
 
       it "is false" do
         expect(described_class.valid?(json)).not_to be_truthy
+      end
+    end
+  end
+
+  describe "#report" do
+    subject(:report) { json_validator.report }
+    let(:json_validator) { described_class.new(json) }
+
+    it "returns empty array if JSON valid" do
+      expect(report).to be_empty
+    end
+
+    context "with invalid json" do
+      let(:json) { invalid }
+
+      it "returns an array of strings describing the problems" do
+        expect(report).to be_present
+        expect(report).to be_a(Array)
+        expect(report.first).to be_a(String)
       end
     end
   end


### PR DESCRIPTION
The reasons are displayed in the records#show page as shown below:

![Invalid metadata report in demo app](https://github.com/user-attachments/assets/2df4149b-475f-4c33-9b6d-496727159be4)
